### PR TITLE
fix: disabled pattern-matching for string.find()

### DIFF
--- a/cve-2020-16898.lua
+++ b/cve-2020-16898.lua
@@ -14,7 +14,7 @@ function match(args)
     -- SCPacketPayload starts at byte 5 of the ICMPv6 header, so we use the packet buffer instead.
     local buffer = SCPacketPayload()
     local search_str = string.sub(buffer, 1, 8)
-    local s, _ = string.find(packet, search_str)
+    local s, _ = string.find(packet, search_str, 1, true)
     local offset = s - 4
 
     -- Only inspect Router Advertisement (Type = 134) ICMPv6 packets.


### PR DESCRIPTION
We are not disabling pattern-matching in our call to string.find() on line 17 of cve-2020-16898,lua, which may cause a pattern-matching error if the packet contains bytes whose ascii values correspond to one of the pattern-matching engine's "magic characters" (see [here](https://www.lua.org/manual/5.3/manual.html#6.4)).

By providing true as the 4th parameter to string.find(), we disable pattern-matching.